### PR TITLE
Fix leftover if-block in setAPISecret

### DIFF
--- a/env.js
+++ b/env.js
@@ -82,12 +82,6 @@ function setAPISecret() {
       var shasum = crypto.createHash('sha1');
       shasum.update(readENV('API_SECRET'));
       env.api_secret = shasum.digest('hex');
-
-      if (!readENV('TREATMENTS_AUTH', true)) {
-
-      }
-
-
     }
   }
 }


### PR DESCRIPTION
## Summary
- clean up `setAPISecret` by removing an empty conditional block

## Testing
- `npm test` *(fails: env-cmd not found)*

------
https://chatgpt.com/codex/tasks/task_e_68443042a7fc832ab104ad8101b89130